### PR TITLE
Correções necessárias para o funcionamento do cakePHP 3

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -10,8 +10,10 @@
  * @license       http://www.opensource.org/licenses/mit-license.php The MIT License
  */
 
+use Cake\Core\Plugin;
+
 // Tradução das mensagens do core
-include Plugin::path('CakePtbr') . 'Config' . DS . 'traducao_core.php';
+include Plugin::path('CakePtbr') . 'config' . DS . 'traducao_core.php';
 
 // Alteração das regras de inflections
-include Plugin::path('CakePtbr') . 'Config' . DS . 'inflections.php';
+include Plugin::path('CakePtbr') . 'config' . DS . 'inflections.php';

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,7 +13,7 @@ arquivo ```config/bootstrap.php``` da seguinte maneira:
 
 ```php
 <?php
-    Plugin::load("CakePtbr");
+    Plugin::load('CakePtbr', ['bootstrap'=> true]);
 ```
 
 ou se o seu arquivo ```bootstrap.php``` possuir o ```Plugin::loadAll()``` pode ignorar este passo.


### PR DESCRIPTION
- Adição do bootstrap true para carregar o bootstrap.php do plugin
- Adição do Use para a classe Plugin ser encontrada
- Correção na documentação
- Criação do arquivo tradução core, pois o arquivo não era localizado